### PR TITLE
Make java path more generic for compatibility

### DIFF
--- a/collectd.spec
+++ b/collectd.spec
@@ -223,7 +223,7 @@ rm -rf %{buildroot}
 %setup
 
 %build
-%configure --with-java=/usr/lib/jvm/java-1.6.0-openjdk-1.6.0.0.x86_64 --enable-java --disable-battery
+%configure --with-java=/usr/lib/jvm/java-1.6.0-openjdk.x86_64/ --enable-java --disable-battery
 make %{?_smp_mflags}
 
 %install


### PR DESCRIPTION
Make --with-java path more generic (specific versions are symlinked to from this path), and add trailing slash for correct `find` behaviour (won't follow symlinks by default -- so configure would fail, not finding the files under the symlinked path).