### PR TITLE
Turn off auto dep generation for contrib

### DIFF
--- a/collectd.spec
+++ b/collectd.spec
@@ -55,6 +55,7 @@ Summary:	All the stuff from the contrib directory
 Group:		System Environment/Daemons
 Requires:	collectd = %{version}, perl(Regexp::Common)
 BuildRequires: perl(Mail::SpamAssassin::Logger), perl(Mail::SpamAssassin::Plugin)
+AutoReqProv: no
 %description contrib
 This package contains all the stuff from the contrib packages.
 


### PR DESCRIPTION
I'm pretty new to RPM packaging, so I'm unsure how wise this is. But since contrib/ includes a wide variety of code, including some for Solaris (which wants to pull in /sbin/sh), I turned this off for my build.