### PR TITLE
Add redis support (plugins 'redis' and 'write_redis')

### DIFF
--- a/collectd.spec
+++ b/collectd.spec
@@ -177,6 +177,15 @@ The python plugin embeds a python interpreter into collectd and provides an
 interface to the collectd's plugin system. This makes it possible to write
 collectd plugins in the python language.
 
+%package redis
+Summary:    redis and write_redis plugins for collectd.
+Group:		System Environment/Daemons
+Requires:	collectd = %{version}, credis
+BuildRequires: credis-devel
+%description redis
+These plugins query redis for status information (redis plugin), and write
+collectd stats to redis (write_redis plugin).
+
 %package rrdtool
 Summary:	rrd-plugin for collectd.
 Group:		System Environment/Daemons
@@ -449,6 +458,10 @@ exit 0
 #%config %attr(0644,root,root) /etc/collectd.d/postgresql.conf
 /usr/share/collectd/postgresql_default.conf
 %plugin_macro postgresql
+
+%files redis
+%plugin_macro redis
+%plugin_macro write_redis
 
 %files rrdtool
 %plugin_macro rrdtool


### PR DESCRIPTION
Yet another one for you. :-P

I built 'credis' and 'credis-devel' packages using https://github.com/jessegonzalez/credis-rpm -- then used those packages as dependencies to build Redis support into collectd. Builds a separate RPM, so you don't have to install credis if you don't want Redis support.

(Note that the dependency on credis is presumably going away with the next collectd release, as the development branch of collectd includes hiredis support already.)